### PR TITLE
FE-18: QA fixes

### DIFF
--- a/src/components/datePicker/DatePicker.tsx
+++ b/src/components/datePicker/DatePicker.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from "react";
+import dayjs from "dayjs";
+import "dayjs/locale/es";
+
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { DatePicker } from "@mui/x-date-pickers";
+import { TextField } from "@mui/material";
+
+dayjs.locale("es");
+
+function dateToString(date: Date): string {
+	try {
+		const year = new Intl.DateTimeFormat("en", { year: "numeric" }).format(date);
+		const month = new Intl.DateTimeFormat("en", { month: "2-digit" }).format(date);
+		const day = new Intl.DateTimeFormat("en", { day: "2-digit" }).format(date);
+		return `${day}-${month}-${year}`;
+	} catch {
+		return "";
+	}
+}
+
+function stringToDateString(stringDate: string | undefined): string | undefined | null {
+	if (!stringDate || !/^(\d{2}-){2}\d{4}$/gm.test(stringDate)) return null;
+	const aux = stringDate.split("-");
+	return new Date(parseInt(aux[2]), parseInt(aux[1]) - 1, parseInt(aux[0])).toString();
+}
+
+export type DatePickerProps = {
+	editable: boolean;
+	date: string | undefined;
+	onChange: (date: string, errorMessage: string) => void;
+	label: string;
+	required?: boolean;
+	width?: string;
+};
+
+export default function DatePickerToString(props: DatePickerProps): React.ReactElement {
+	const { editable, date, onChange, label, required, width } = props;
+
+	const [pickerDate, setPickerDate] = useState<string | null | undefined>(stringToDateString(date));
+	const [errorMessage, setErrorMessage] = useState<string>("");
+
+	const validDateError = "Debe ser una fecha válida.";
+
+	function AssignDate(newValue: string | null | undefined, errorMessage: string): void {
+		let stringDate = "";
+		if (newValue) {
+			const date = new Date(newValue);
+			stringDate = dateToString(date);
+		}
+		setErrorMessage(errorMessage);
+		onChange(stringDate, errorMessage);
+	}
+
+	return (
+		<LocalizationProvider dateAdapter={AdapterDayjs}>
+			<DatePicker
+				readOnly={!editable}
+				label={label}
+				value={pickerDate}
+				onAccept={(newValue): void => {
+					setPickerDate(newValue);
+					AssignDate(newValue, "");
+				}}
+				onChange={(newValue): void => {
+					setPickerDate(newValue);
+					let error = errorMessage;
+					if (!newValue && required) {
+						error = validDateError;
+					}
+					if (errorMessage == "") {
+						AssignDate(newValue, error);
+					} else {
+						AssignDate(null, error);
+					}
+				}}
+				onError={(reason, newValue): void => {
+					setPickerDate(newValue);
+					let dateToSet = newValue;
+					let error = newValue;
+					switch (reason) {
+						case "invalidDate":
+							error = validDateError;
+							dateToSet = null;
+							break;
+						case null:
+							if (!newValue && required) {
+								error = validDateError;
+							} else {
+								error = "";
+							}
+							break;
+						default:
+							error = reason;
+							dateToSet = null;
+							break;
+					}
+					AssignDate(dateToSet, error);
+				}}
+				renderInput={(params): React.ReactElement => (
+					<TextField
+						{...params}
+						variant="standard"
+						helperText={errorMessage}
+						required={required}
+						error={errorMessage != ""}
+						sx={{ display: "flex", width: width ? width : "100%" }}
+					/>
+				)}
+			/>
+		</LocalizationProvider>
+	);
+}

--- a/src/core/Parsers.ts
+++ b/src/core/Parsers.ts
@@ -19,7 +19,7 @@ export function parseFormToStudent(form: StudentCreationForm, student: Student):
 			first_language: form["Lengua materna:"],
 			medical_assurance: form["Cobertura médica:"],
 			emergency: form["Emergencia médica:"],
-			vaccine_expiration: form["Fecha de vencimiento de vacunas:"],
+			vaccine_expiration: addLeadingZeroToDate(form["Fecha de vencimiento de vacunas:"]),
 			family: [
 				{
 					role: form["Datos correspondientes a:"],

--- a/src/pages/student/DefaultStudent.tsx
+++ b/src/pages/student/DefaultStudent.tsx
@@ -1,12 +1,12 @@
 import { DiscountExplanation, DiscountType, PaymentMethodOption, ScholarshipType, Student } from "../../core/Models";
 
 export const defaultStudent: Student = {
-	id: "asdf",
-	ci: "asdf",
-	name: "asdf",
-	surname: "asda",
-	schedule_start: "asdf",
-	schedule_end: "asdf",
+	id: "",
+	ci: "",
+	name: "",
+	surname: "",
+	schedule_start: "",
+	schedule_end: "",
 	tuition: "",
 	reference_number: 0,
 	birthplace: "",

--- a/src/pages/student/Student.tsx
+++ b/src/pages/student/Student.tsx
@@ -61,7 +61,10 @@ export default function Student(props: StudentProps): React.ReactElement {
 		{ label: "Administrativa", dataCY: "administrativeInfoTab" },
 	];
 
-	const debouncedSetStudent = React.useCallback(_.debounce(setStudent, 200), []);
+	const debouncedSetStudent = React.useCallback(
+		(student: StudentModel, debounce = true) => (debounce ? _.debounce(setStudent, 200)(student) : setStudent(student)),
+		[]
+	);
 
 	const translator = (id: string, defaultMessage: string): string => {
 		if ((id.includes("date") || id.includes("expiration")) && id.includes("required")) return "Debe ser una fecha válida.";

--- a/src/pages/student/Student.tsx
+++ b/src/pages/student/Student.tsx
@@ -36,6 +36,7 @@ export default function Student(props: StudentProps): React.ReactElement {
 	const [student, setStudent] = React.useState<StudentModel>(defaultStudent);
 	const [isEditable, setIsEditable] = React.useState(false);
 	const [fetchState, setFetchState] = React.useState(FetchState.loading);
+	const [warnings, setWarnings] = React.useState<string[][]>([[], [], [], []]);
 
 	const getStudent = useCallback(async (): Promise<void> => {
 		setFetchState(FetchState.loading);
@@ -63,6 +64,7 @@ export default function Student(props: StudentProps): React.ReactElement {
 	const debouncedSetStudent = React.useCallback(_.debounce(setStudent, 200), []);
 
 	const translator = (id: string, defaultMessage: string): string => {
+		if ((id.includes("date") || id.includes("expiration")) && id.includes("required")) return "Debe ser una fecha válida.";
 		if (id.includes("required")) return "Este campo es requerido.";
 		else return defaultMessage;
 	};
@@ -71,7 +73,17 @@ export default function Student(props: StudentProps): React.ReactElement {
 		<StudentInfo student={student} onChange={debouncedSetStudent} editable={isEditable} translator={translator} />,
 		<FamilyForm student={student} onChange={debouncedSetStudent} editable={isEditable} translator={translator} />,
 		<EnrollmentQuestions student={student} onChange={debouncedSetStudent} editable={isEditable} />,
-		<AdministrativeInfo student={student} onChange={debouncedSetStudent} editable={isEditable} translator={translator} />,
+		<AdministrativeInfo
+			student={student}
+			onChange={debouncedSetStudent}
+			editable={isEditable}
+			translator={translator}
+			setWarnings={(warning: string[]): void => {
+				const newWarnings = warnings.slice();
+				newWarnings[3] = warning;
+				setWarnings(newWarnings);
+			}}
+		/>,
 	];
 
 	if (fetchState === FetchState.loading) return <CircularProgress />;
@@ -106,7 +118,16 @@ export default function Student(props: StudentProps): React.ReactElement {
 				student={student}
 			/>
 
-			<StudentPageTabs tabData={tabData} onChange={setCurrentTabIndex} value={currentTabIndex} />
+			<StudentPageTabs
+				tabData={tabData}
+				onChange={(newValue: number) => {
+					const newWarnings = warnings.slice();
+					newWarnings[currentTabIndex] = [];
+					setWarnings(newWarnings);
+					setCurrentTabIndex(newValue);
+				}}
+				value={currentTabIndex}
+			/>
 
 			{panels.map((panel, index) => (
 				<TabPanel key={`student-tab-panel-${index}`} className="panel-item" value={currentTabIndex} index={index}>
@@ -114,7 +135,9 @@ export default function Student(props: StudentProps): React.ReactElement {
 				</TabPanel>
 			))}
 
-			{[StudentPageMode.create, StudentPageMode.edit].includes(mode) && <CreateStudentDialog student={student} mode={mode} />}
+			{[StudentPageMode.create, StudentPageMode.edit].includes(mode) && (
+				<CreateStudentDialog student={student} mode={mode} warnings={warnings[currentTabIndex]} />
+			)}
 		</Card>
 	);
 }

--- a/src/pages/student/components/AdministrativeInfo/AdministrativeInfo.tsx
+++ b/src/pages/student/components/AdministrativeInfo/AdministrativeInfo.tsx
@@ -1,23 +1,24 @@
 /* eslint-disable */
 import React, { useState } from "react";
+
 import { JsonForms } from "@jsonforms/react";
 import { JsonSchema7, Translator } from "@jsonforms/core";
 import { materialCells, materialRenderers } from "@jsonforms/material-renderers";
 import { createAjv } from "@jsonforms/core";
+import { FormControl, InputLabel, MenuItem, Select, TextField, Container, Card, CardContent } from "@mui/material";
+import DownloadIcon from "@mui/icons-material/Download";
 import { DataStore } from "../../../../core/DataStore";
 import * as Models from "../../../../core/Models";
 import { VisualComponent } from "../../../../core/interfaces";
 import FileUploader from "../../../../components/fileUploader/FileUploader";
-import { FormControl, InputLabel, MenuItem, Select, TextField, Container, Card, CardContent } from "@mui/material";
-import DownloadIcon from "@mui/icons-material/Download";
+import DiscountsSection from "./DiscountsSection/DiscountsSection";
+import PaymentMethodSection from "./PaymentMethodsSection/PaymentMethodSection";
+import DatePickerToString from "../../../../components/datePicker/DatePicker";
 
 import schema from "../../schema.json";
 import uiSchema from "./ui.json";
 
 import "./AdministrativeInfo.scss";
-
-import DiscountsSection from "./DiscountsSection/DiscountsSection";
-import PaymentMethodSection from "./PaymentMethodsSection/PaymentMethodSection";
 import NumericInputControl, { NumericInputControlTester } from "../../../../components/NumericInput/NumericInputControl";
 
 export type AdministrativeInfoProps = {
@@ -25,6 +26,7 @@ export type AdministrativeInfoProps = {
 	student: Models.Student;
 	onChange: (data: Models.Student) => void;
 	translator?: (id: string, defaultMessage: string) => string;
+	setWarnings: (message: string[]) => void;
 };
 
 const renderers = [...materialRenderers, { tester: NumericInputControlTester, renderer: NumericInputControl }];
@@ -32,18 +34,55 @@ const renderers = [...materialRenderers, { tester: NumericInputControlTester, re
 export default function AdministrativeInfo(props: VisualComponent & AdministrativeInfoProps): React.ReactElement {
 	const dataStore = DataStore.getInstance();
 
-	const { editable, student, translator, onChange } = props;
+	const { editable, student, translator, onChange, setWarnings } = props;
 
 	const [enrollmentCommitment, setEnrollmentCommitment] = useState<File | undefined>();
 	const [agreementType, setAgreementType] = useState<string | undefined>(undefined);
+	const [warnings, setWarningMessages] = useState<string[]>(["", ""]);
 
 	const handleDefaultsAjv = createAjv({ useDefaults: true });
+
+	function GenerateWarnings(warnings: string[]): string[] {
+		if (!warnings[0] && !warnings[1]) return [];
+		return [
+			"Información Administrativa \n",
+			warnings[0] ? "Fecha de inscripción: " + warnings[0] : "",
+			warnings[1] ? "Fecha de comienzo: " + warnings[1] : "",
+		];
+	}
+
+	function SetWarningMessage(index: number, message: string): void {
+		const newWarnings = warnings.slice();
+		newWarnings[index] = message;
+		setWarningMessages(newWarnings);
+		setWarnings(GenerateWarnings(newWarnings));
+	}
 
 	return (
 		<Container className="administrative-info" sx={{ display: "flex" }}>
 			<Container className="payment-details-wrapper" sx={{ display: "flex" }}>
 				<Card className="form-container" color={"primary"} sx={{ overflow: "auto" }}>
 					<CardContent>
+						<DatePickerToString
+							editable={editable}
+							date={student.administrative_info.enrollment_date}
+							onChange={(date: string, errorMessage: string) => {
+								const newStudent = { ...student, administrative_info: { ...student.administrative_info, enrollment_date: date } };
+								onChange(newStudent);
+								SetWarningMessage(0, errorMessage);
+							}}
+							label="Fecha de inscripción"
+						/>
+						<DatePickerToString
+							editable={editable}
+							date={student.administrative_info.starting_date}
+							onChange={(date: string, errorMessage: string) => {
+								const newStudent = { ...student, administrative_info: { ...student.administrative_info, starting_date: date } };
+								onChange(newStudent);
+								SetWarningMessage(1, errorMessage);
+							}}
+							label="Fecha de comienzo"
+						/>
 						<JsonForms
 							i18n={{ translate: translator as Translator }}
 							schema={schema as JsonSchema7}

--- a/src/pages/student/components/AdministrativeInfo/AdministrativeInfo.tsx
+++ b/src/pages/student/components/AdministrativeInfo/AdministrativeInfo.tsx
@@ -24,7 +24,7 @@ import NumericInputControl, { NumericInputControlTester } from "../../../../comp
 export type AdministrativeInfoProps = {
 	editable: boolean;
 	student: Models.Student;
-	onChange: (data: Models.Student) => void;
+	onChange: (data: Models.Student, debounce?: boolean) => void;
 	translator?: (id: string, defaultMessage: string) => string;
 	setWarnings: (message: string[]) => void;
 };

--- a/src/pages/student/components/AdministrativeInfo/DiscountsSection/DiscountsSection.scss
+++ b/src/pages/student/components/AdministrativeInfo/DiscountsSection/DiscountsSection.scss
@@ -18,3 +18,14 @@
 	height: 340px;
 	margin: 5px 0;
 }
+
+.dates-container {
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 5px;
+	margin-top: 5px;
+}
+
+.alert {
+	margin-top: 20px;
+}

--- a/src/pages/student/components/AdministrativeInfo/DiscountsSection/DiscountsSection.tsx
+++ b/src/pages/student/components/AdministrativeInfo/DiscountsSection/DiscountsSection.tsx
@@ -6,6 +6,7 @@ import { VisualComponent } from "../../../../../core/interfaces";
 import Modal from "../../../../../components/modal/Modal";
 import DiscountHistory from ".././historyTables/DiscountHistory";
 import FileUploader from "../../../../../components/fileUploader/FileUploader";
+import DatePickerToString from "../../../../../components/datePicker/DatePicker";
 import { Card, CardContent, Divider, IconButton, Container, Typography, Box, Alert } from "@mui/material";
 import { JsonForms } from "@jsonforms/react";
 import { JsonSchema7, Translator } from "@jsonforms/core";
@@ -139,6 +140,33 @@ export default function DiscountsSection(props: VisualComponent & Administrative
 								{discountData.explanation == Models.DiscountExplanation.Resolution.valueOf() ? (
 									<Container style={{ paddingRight: "0px", paddingLeft: "0px", paddingTop: "15px" }}>
 										<Typography>{"Resolución"}</Typography>
+
+										<Box className="dates-container">
+											<DatePickerToString
+												width={'48%'}
+												editable={true}
+												date={discountData.starting_date}
+												onChange={(date: string): void => {
+													const newDiscount = { ...discountData, starting_date: date };
+													setDiscountData(newDiscount);
+												}}
+												label="Comienzo"
+												required={true}
+											/>
+
+											<DatePickerToString
+												width={'48%'}
+												editable={true}
+												date={discountData.ending_date}
+												onChange={(date: string): void => {
+													const newDiscount = { ...discountData, ending_date: date };
+													setDiscountData(newDiscount);
+												}}
+												label="Fin"
+												required={true}
+											/>
+										</Box>
+
 										<JsonForms
 											i18n={{ translate: translator as Translator }}
 											schema={schema.properties.administrative_info.properties.discounts.items as JsonSchema7}
@@ -170,7 +198,7 @@ export default function DiscountsSection(props: VisualComponent & Administrative
 										<FileUploader label={"Informe"} width={"100%"} uploadedFile={(file): void => setReportFile(file)} />
 									</Container>
 								) : null}
-								{hasDateErrors ? <Alert severity="error">La fecha de fin debe ser posterior a la fecha de inicio</Alert> : null}
+								{hasDateErrors ? <Alert severity="error" className="alert">La fecha de fin debe ser posterior a la fecha de comienzo</Alert> : null}
 							</Container>
 						</Modal>
 					</Box>

--- a/src/pages/student/components/AdministrativeInfo/DiscountsSection/ui-report.json
+++ b/src/pages/student/components/AdministrativeInfo/DiscountsSection/ui-report.json
@@ -3,7 +3,7 @@
 	"elements": [
 		{
 			"type": "Control",
-			"scope": "#/properties//type"
+			"scope": "#/properties/type"
 		}
 	]
 }

--- a/src/pages/student/components/AdministrativeInfo/DiscountsSection/ui-resolution.json
+++ b/src/pages/student/components/AdministrativeInfo/DiscountsSection/ui-resolution.json
@@ -3,24 +3,6 @@
 	"elements": [
 		{
 			"type": "Control",
-			"scope": "#/properties/starting_date",
-			"options": {
-				"format": "date",
-				"dateFormat": "DD/MM/YYYY",
-				"dateSaveFormat": "MM-DD-YYYY"
-			}
-		},
-		{
-			"type": "Control",
-			"scope": "#/properties/ending_date",
-			"options": {
-				"format": "date",
-				"dateFormat": "DD/MM/YYYY",
-				"dateSaveFormat": "MM-DD-YYYY"
-			}
-		},
-		{
-			"type": "Control",
 			"scope": "#/properties/description"
 		}
 	]

--- a/src/pages/student/components/AdministrativeInfo/ui.json
+++ b/src/pages/student/components/AdministrativeInfo/ui.json
@@ -3,24 +3,6 @@
 	"elements": [
 		{
 			"type": "Control",
-			"scope": "#/properties/administrative_info/properties/enrollment_date",
-			"options": {
-				"format": "date",
-				"dateFormat": "DD/MM/YYYY",
-				"dateSaveFormat": "DD/MM/YYYY"
-			}
-		},
-		{
-			"type": "Control",
-			"scope": "#/properties/administrative_info/properties/starting_date",
-			"options": {
-				"format": "date",
-				"dateFormat": "DD/MM/YYYY",
-				"dateSaveFormat": "DD/MM/YYYY"
-			}
-		},
-		{
-			"type": "Control",
 			"scope": "#/properties/administrative_info/properties/scholarship_type"
 		}
 	]

--- a/src/pages/student/components/CreateStudentDialog/CreateStudentDialog.tsx
+++ b/src/pages/student/components/CreateStudentDialog/CreateStudentDialog.tsx
@@ -5,7 +5,7 @@ import * as API from "../../../../core/ApiStore";
 import { ajv as studentAjv, getAjvErrors, getParsedErrors } from "../../../../core/AJVHelper";
 import { StudentPageMode } from "../../../../core/interfaces";
 
-import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Typography } from "@mui/material";
+import { Alert, AlertTitle, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider, List, ListItem, Typography } from "@mui/material";
 import { LoadingButton } from "@mui/lab";
 import ErrorList from "../../../../components/ErrorList/ErrorList";
 
@@ -14,10 +14,11 @@ import studentSchema from "../../schema.json";
 interface CreateStudentDialogProps {
 	student: Student;
 	mode?: StudentPageMode;
+	warnings?: string[];
 }
 
 function CreateStudentDialog(props: CreateStudentDialogProps): React.ReactElement {
-	const { student, mode: modeProps } = props;
+	const { student, mode: modeProps, warnings } = props;
 	const mode = modeProps ?? StudentPageMode.create;
 
 	const [isOpen, setIsOpen] = React.useState(false);
@@ -94,6 +95,18 @@ function CreateStudentDialog(props: CreateStudentDialogProps): React.ReactElemen
 
 						<Box height="400px" overflow="auto" paddingTop="12px">
 							<ErrorList name="Errores" path="" value={errors} schema={studentSchema} />
+							{warnings ? (
+								warnings.length > 0 ? (
+									<Alert variant="outlined" severity="warning">
+										<AlertTitle>{warnings[0]}</AlertTitle>
+										<List>
+											{warnings.map((text, messageIndex) =>
+												messageIndex == 0 || !text ? null : <ListItem key={messageIndex}>{text}</ListItem>
+											)}
+										</List>
+									</Alert>
+								) : null
+							) : null}
 						</Box>
 					</DialogContent>
 

--- a/src/pages/student/components/EnrollmentQuestions/EnrollmentQuestions.tsx
+++ b/src/pages/student/components/EnrollmentQuestions/EnrollmentQuestions.tsx
@@ -8,7 +8,7 @@ import useDebounce from "../../../../hooks/useDebounce";
 export interface EnrollmentQuestionsProps {
 	student: Student;
 	editable: boolean;
-	onChange: (newStudent: Student) => void;
+	onChange: (newStudent: Student, debounce?: boolean) => void;
 }
 
 function Question(props: {

--- a/src/pages/student/components/FamilyForm/FamilyForm.tsx
+++ b/src/pages/student/components/FamilyForm/FamilyForm.tsx
@@ -8,6 +8,7 @@ import { materialRenderers } from "@jsonforms/material-renderers";
 import { Box, ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { defaultStudent } from "../../DefaultStudent";
 import NumericInputControl, { NumericInputControlTester } from "../../../../components/NumericInput/NumericInputControl";
+import DatePickerToString from "../../../../components/datePicker/DatePicker";
 
 import schema from "../../schema.json";
 import ui from "./ui.json";
@@ -87,6 +88,17 @@ export default function FamilyForm(props: FamilyFormProps): React.ReactElement {
 				onChange={({ data }): void => setCurrentData(data)}
 				validationMode="ValidateAndShow"
 				readonly={!editable}
+			/>
+			<DatePickerToString
+				editable={editable}
+				date={family[familyIndex]?.birthdate}
+				onChange={(date: string): void => {
+					const newFamily = student.family.slice();
+					newFamily[familyIndex] = { ...newFamily[familyIndex], birthdate: date };
+					const newStudent = { ...student, family: newFamily };
+					onChange(newStudent);
+				}}
+				label="Fecha de nacimiento"
 			/>
 		</Box>
 	);

--- a/src/pages/student/components/FamilyForm/FamilyForm.tsx
+++ b/src/pages/student/components/FamilyForm/FamilyForm.tsx
@@ -14,6 +14,7 @@ import schema from "../../schema.json";
 import ui from "./ui.json";
 
 import "./FamilyForm.scss";
+import DatePickerToString from "../../../../components/datePicker/DatePicker";
 
 export type FamilyFormProps = {
 	student: Student;

--- a/src/pages/student/components/FamilyForm/FamilyForm.tsx
+++ b/src/pages/student/components/FamilyForm/FamilyForm.tsx
@@ -14,7 +14,6 @@ import schema from "../../schema.json";
 import ui from "./ui.json";
 
 import "./FamilyForm.scss";
-import DatePickerToString from "../../../../components/datePicker/DatePicker";
 
 export type FamilyFormProps = {
 	student: Student;

--- a/src/pages/student/components/FamilyForm/FamilyForm.tsx
+++ b/src/pages/student/components/FamilyForm/FamilyForm.tsx
@@ -19,7 +19,7 @@ import DatePickerToString from "../../../../components/datePicker/DatePicker";
 export type FamilyFormProps = {
 	student: Student;
 	editable: boolean;
-	onChange: (data: Student) => void;
+	onChange: (data: Student, debounce?: boolean) => void;
 	translator?: (id: string, defaultMessage: string) => string;
 };
 
@@ -48,7 +48,7 @@ export default function FamilyForm(props: FamilyFormProps): React.ReactElement {
 		onChange({
 			...student,
 			family: [...student.family, defaultStudent.family[0]],
-		});
+		}, false);
 	}
 
 	const toggleButtons = useCallback(

--- a/src/pages/student/components/FamilyForm/ui.json
+++ b/src/pages/student/components/FamilyForm/ui.json
@@ -37,10 +37,6 @@
 				{
 					"type": "Control",
 					"scope": "properties/cellphone"
-				},
-				{
-					"type": "Control",
-					"scope": "properties/education_level"
 				}
 			]
 		},
@@ -83,15 +79,15 @@
 			"elements": [
 				{
 					"type": "Control",
+					"scope": "properties/education_level"
+				},
+				{
+					"type": "Control",
 					"scope": "properties/occupation"
 				},
 				{
 					"type": "Control",
 					"scope": "properties/workplace"
-				},
-				{
-					"type": "Control",
-					"scope": "properties/workplace_phone"
 				}
 			]
 		},
@@ -105,6 +101,10 @@
 				{
 					"type": "Control",
 					"scope": "properties/workplace_neighbourhood"
+				},
+				{
+					"type": "Control",
+					"scope": "properties/workplace_phone"
 				}
 			]
 		}

--- a/src/pages/student/components/FamilyForm/ui.json
+++ b/src/pages/student/components/FamilyForm/ui.json
@@ -26,7 +26,7 @@
 					"scope": "properties/birthdate",
 					"options": {
 						"format": "date",
-						"dateFormat": "DD-MM-YYYY",
+						"dateFormat": "DD/MM/YYYY",
 						"dateSaveFormat": "DD-MM-YYYY"
 					}
 				},

--- a/src/pages/student/components/FamilyForm/ui.json
+++ b/src/pages/student/components/FamilyForm/ui.json
@@ -37,6 +37,10 @@
 				{
 					"type": "Control",
 					"scope": "properties/cellphone"
+				},
+				{
+					"type": "Control",
+					"scope": "properties/education_level"
 				}
 			]
 		},
@@ -79,15 +83,15 @@
 			"elements": [
 				{
 					"type": "Control",
-					"scope": "properties/education_level"
-				},
-				{
-					"type": "Control",
 					"scope": "properties/occupation"
 				},
 				{
 					"type": "Control",
 					"scope": "properties/workplace"
+				},
+				{
+					"type": "Control",
+					"scope": "properties/workplace_phone"
 				}
 			]
 		},
@@ -101,10 +105,6 @@
 				{
 					"type": "Control",
 					"scope": "properties/workplace_neighbourhood"
-				},
-				{
-					"type": "Control",
-					"scope": "properties/workplace_phone"
 				}
 			]
 		}

--- a/src/pages/student/components/StudentInfo/StudentInfo.tsx
+++ b/src/pages/student/components/StudentInfo/StudentInfo.tsx
@@ -15,7 +15,7 @@ import "./StudentInfo.scss";
 
 export type StudentInfoProps = {
 	student: Student;
-	onChange: (data: Student) => void;
+	onChange: (data: Student, debounce?: boolean) => void;
 	editable: boolean;
 	translator?: (id: string, defaultMessage: string) => string;
 };

--- a/src/pages/student/components/StudentInfo/ui.json
+++ b/src/pages/student/components/StudentInfo/ui.json
@@ -13,8 +13,8 @@
 					"scope": "#/properties/surname"
 				},
 				{
-				  "type": "Control",
-				  "scope": "#/properties/ci"
+					"type": "Control",
+					"scope": "#/properties/ci"
 				}
 			]
 		},
@@ -30,8 +30,8 @@
 					"scope": "#/properties/tuition"
 				},
 				{
-				  "type": "Control",
-				  "scope": "#/properties/reference_number"
+					"type": "Control",
+					"scope": "#/properties/reference_number"
 				}
 			]
 		},
@@ -47,8 +47,8 @@
 					"scope": "#/properties/subgroup"
 				},
 				{
-				  "type": "Control",
-				  "scope": "#/properties/birthplace"
+					"type": "Control",
+					"scope": "#/properties/birthplace"
 				}
 			]
 		},
@@ -56,21 +56,21 @@
 			"type": "HorizontalLayout",
 			"elements": [
 				{
-				  "type": "Control",
-				  "scope": "#/properties/birthdate",
-				  "options": {
-					"format": "date",
-					"dateFormat": "DD/MM/YYYY",
-					"dateSaveFormat": "DD/MM/YYYY"
-				  }
+					"type": "Control",
+					"scope": "#/properties/birthdate",
+					"options": {
+						"format": "date",
+						"dateFormat": "DD/MM/YYYY",
+						"dateSaveFormat": "DD-MM-YYYY"
+					}
 				},
 				{
 					"type": "Control",
 					"scope": "#/properties/nationality"
 				},
 				{
-				  "type": "Control",
-				  "scope": "#/properties/first_language"
+					"type": "Control",
+					"scope": "#/properties/first_language"
 				}
 			]
 		},
@@ -78,16 +78,16 @@
 			"type": "HorizontalLayout",
 			"elements": [
 				{
-				  "type": "Control",
-				  "scope": "#/properties/neighborhood"
+					"type": "Control",
+					"scope": "#/properties/neighborhood"
 				},
 				{
 					"type": "Control",
 					"scope": "#/properties/address"
 				},
 				{
-				  "type": "Control",
-				  "scope": "#/properties/phone_number"
+					"type": "Control",
+					"scope": "#/properties/phone_number"
 				}
 			]
 		},
@@ -108,7 +108,7 @@
 					"options": {
 						"format": "date",
 						"dateFormat": "DD/MM/YYYY",
-						"dateSaveFormat": "DD/MM/YYYY"
+						"dateSaveFormat": "DD-MM-YYYY"
 					}
 				}
 			]

--- a/src/pages/student/schema.json
+++ b/src/pages/student/schema.json
@@ -7,9 +7,8 @@
 		"ci": {
 			"type": "string",
 			"title": "CI",
-			"pattern": "^((\\d+)|([a-zA-Z]+))+$",
 			"minLength": 1,
-			"errorMessage": "Se deben ingresar solo números y letras, sin puntos ni guiones."
+		  	"errorMessage": "Este campo es requerido."
 		},
 		"name": {
 			"type": "string",
@@ -186,9 +185,8 @@
 					"ci": {
 						"type": "string",
 						"title": "Cédula de identidad",
-						"pattern": "^((\\d+)|([a-zA-Z]+))+$",
 						"minLength": 1,
-						"errorMessage": "Debe ingresar solo números o letras, sin puntos ni guiones."
+					  	"errorMessage": "Este campo es requerido."
 					},
 					"marital_status": {
 						"type": "string",
@@ -433,14 +431,6 @@
 					"items": {
 						"type": "object",
 						"properties": {
-							"starting_date": {
-								"title": "Comienzo",
-								"type": "string"
-							},
-							"ending_date": {
-								"title": "Fin",
-								"type": "string"
-							},
 							"explanation": {
 								"oneOf": [
 									{
@@ -488,7 +478,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["starting_date", "ending_date", "explanation", "percentage", "report_url"]
+						"required": ["explanation", "percentage", "report_url"]
 					}
 				}
 			}

--- a/src/pages/student/schema.json
+++ b/src/pages/student/schema.json
@@ -49,10 +49,7 @@
 			"type": "string",
 			"title": "Fecha de nacimiento",
 			"minLength": 1,
-			"errorMessage": {
-				"format": "Tiene que ser una fecha válida.",
-				"minLength": "Este campo es requerido."
-			}
+			"errorMessage": "Debe ser una fecha válida."
 		},
 		"nationality": {
 			"type": "string",
@@ -116,25 +113,7 @@
 			"type": "string",
 			"title": "Vencimiento de vacunas",
 			"minLength": 1,
-			"errorMessage": {
-				"format": "Tiene que ser una fecha válida.",
-				"minLength": "Este campo es requerido."
-			}
-		},
-		"inscription_date": {
-			"type": "string",
-			"title": "Fecha de inscripción",
-			"errorMessage": {
-				"format": "Tiene que ser una fecha válida."
-			}
-		},
-		"starting_date": {
-			"type": "string",
-			"format": "date",
-			"title": "Fecha de inicio",
-			"errorMessage": {
-				"format": "Tiene que ser una fecha válida."
-			}
+			"errorMessage": "Debe ser una fecha válida."
 		},
 		"contact": {
 			"type": "string",
@@ -184,7 +163,7 @@
 						"type": "string",
 						"title": "Fecha de nacimiento",
 						"minLength": 1,
-						"errorMessage": "Este campo es requerido."
+						"errorMessage": "Debe ser una fecha válida."
 					},
 					"birthplace": {
 						"type": "string",

--- a/src/pages/student/schema.json
+++ b/src/pages/student/schema.json
@@ -478,7 +478,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["explanation", "percentage", "report_url"]
+						"required": ["explanation", "percentage"]
 					}
 				}
 			}

--- a/src/pages/user/CreateUser.tsx
+++ b/src/pages/user/CreateUser.tsx
@@ -12,6 +12,7 @@ import { Button, Card, CardContent } from "@mui/material";
 
 import NumericInputControl, { NumericInputControlTester } from "../../components/NumericInput/NumericInputControl";
 import CreateUserDialog from "./components/CreateUserDialog";
+import DatePickerToString from "../../components/datePicker/DatePicker";
 
 import schema from "./schema.json";
 import ui from "./ui.json";
@@ -19,7 +20,7 @@ import ui from "./ui.json";
 const renderers = [...materialRenderers, { tester: NumericInputControlTester, renderer: NumericInputControl }];
 
 export default function CreateUser(): React.ReactElement {
-	const [data, setData] = useState({});
+	const [data, setData] = useState<Models.User>({} as Models.User);
 	const [errors, setErrors] = useState<ErrorObject[]>([]);
 	const [validationMode, setValidationMode] = useState<ValidationMode>("ValidateAndHide");
 	const [userCreationState, setUserCreationState] = React.useState<CreationState>(CreationState.idle);
@@ -68,6 +69,15 @@ export default function CreateUser(): React.ReactElement {
 						setData(data);
 					}}
 					validationMode={validationMode}
+				/>
+				<DatePickerToString
+					editable={true}
+					date={data.birthdate}
+					onChange={(date: string): void => {
+						const newUser = { ...data, birthdate: date };
+						setData(newUser);
+					}}
+					label="Fecha de nacimiento"
 				/>
 
 				<Button id="createButton" variant="contained" onClick={handleUserCreation} sx={{ marginTop: 10 }}>

--- a/src/pages/user/ui.json
+++ b/src/pages/user/ui.json
@@ -1,49 +1,40 @@
 {
-  "type": "VerticalLayout",
-  "elements": [
-	{
-	  "type": "Control",
-	  "scope": "#/properties/email"
-	},
-	{
-	  "type": "Control",
-	  "scope": "#/properties/password",
-	  "options": {
-		"format": "password"
-	  }
-	},
-	{
-	  "type": "Control",
-	  "scope": "#/properties/name"
-	},
-	{
-	  "type": "Control",
-	  "scope": "#/properties/surname"
-	},
-	{
-	  "type": "Control",
-	  "scope": "#/properties/role"
-	},
-	{
-	  "type": "Control",
-	  "scope": "#/properties/birthdate",
-	  "options": {
-		"format": "date",
-		"dateFormat": "DD-MM-YYYY",
-		"dateSaveFormat": "DD-MM-YYYY"
-	  }
-	},
-	{
-	  "type": "Control",
-	  "scope": "#/properties/ci"
-	},
-	{
-	  "type": "Control",
-	  "scope": "#/properties/phone"
-	},
-	{
-	  "type": "Control",
-	  "scope": "#/properties/address"
-	}
-  ]
+	"type": "VerticalLayout",
+	"elements": [
+		{
+			"type": "Control",
+			"scope": "#/properties/email"
+		},
+		{
+			"type": "Control",
+			"scope": "#/properties/password",
+			"options": {
+				"format": "password"
+			}
+		},
+		{
+			"type": "Control",
+			"scope": "#/properties/name"
+		},
+		{
+			"type": "Control",
+			"scope": "#/properties/surname"
+		},
+		{
+			"type": "Control",
+			"scope": "#/properties/role"
+		},
+		{
+			"type": "Control",
+			"scope": "#/properties/ci"
+		},
+		{
+			"type": "Control",
+			"scope": "#/properties/phone"
+		},
+		{
+			"type": "Control",
+			"scope": "#/properties/address"
+		}
+	]
 }


### PR DESCRIPTION
Este PR usa el componente DatePicker de FE-109 y no se puede mergear hasta que no esté mergeado FE-109.

Correcciones:
- Eliminado error de la CI cuando se ingresan guiones ya que en backend son permitidos. Ahora solo se muestra error de que es un campo requerido si queda vacío.
- Corregido el mensaje de error en inglés "must be object" cuando se crea un familiar y se dejan todos los campos vacíos. Ahora se muestran los mensajes de error de cada campo, ya sean requeridos o por el pattern.
- Los campos fecha de comienzo y fin de un descuento por resolución ya no se muestran en la lista de errores si no se creó un descuento (La creación del descuento se limita dentro del modal si estas fechas no se ingresan).

Para corregir el error de la creación de un familiar, se agregó la prop "debounce" a la función onChange de los componentes de Student, para poder usarlo o no según sea necesario. El uso del debounce estaba haciendo que el segundo familiar se generara como undefined y por eso mostrara un error.