### PR TITLE
BUG-307: Añade vista de alumnos al administrador.

### DIFF
--- a/src/core/userRoleHelper.ts
+++ b/src/core/userRoleHelper.ts
@@ -55,6 +55,31 @@ export function getSidebarSectionsByUser(user: User | null): SidebarSection[] {
 					],
 				},
 				{
+					sectionTitle: "Alumnos",
+					items: [
+						{
+							title: "Activos",
+							navigationRoute: `/students/active`,
+						},
+						{
+							title: "Pendientes",
+							navigationRoute: `/pending`,
+						},
+						{
+							title: "Inactivos",
+							navigationRoute: `/students/inactive`,
+						},
+						{
+							title: "Ver todos",
+							navigationRoute: `/students`,
+						},
+						{
+							title: "Dar de alta",
+							navigationRoute: "/createstudent",
+						},
+					],
+				},
+				{
 					sectionTitle: "Convenios",
 					items: [
 						{


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/VL6kE97u/307-1bug-307-un-usuario-administrador-no-puede-ver-las-p%C3%A1ginas-de-alumnos-en-el-sidebar)